### PR TITLE
Adding normalAttackFlag to the enemy move data structure

### DIFF
--- a/docs/ENEMY_MOVES_HARDMODE.CSV
+++ b/docs/ENEMY_MOVES_HARDMODE.CSV
@@ -1,4 +1,4 @@
-Enemy,Move,MP,SP,???,Target Effect,STR,POW,AD,Target Type,???,Distance,Accuracy,Range,Cast Time,Recovery,Animation,Knockdown,IP Stun,IP Cancel Stun,Knockback,Element,Element Strength,Status Effect Bitflag,Status Effect Chance,ATK Change,DEF Change,ACT Change,MOV Change,Special
+Enemy,Move,MP,SP,???,Target Effect,STR,POW,AD,Target Type,Normal Attack Flag,Distance,Accuracy,Range,Cast Time,Recovery,Animation,Knockdown,IP Stun,IP Cancel Stun,Knockback,Element,Element Strength,Status Effect Bitflag,Status Effect Chance,ATK Change,DEF Change,ACT Change,MOV Change,Special
           Big Foot,            Attack,0,0,1,Physical Damage(STR),85,200,85,One Enemy,1,150,100,0,60,9999,0,0,0,0,120,Blizzard,9,0,0,0,0,0,0,0
   Huge Caterpillar,            Attack,0,0,20,Physical Damage(STR),90,150,90,One Enemy,1,50,300,0,30,9999,0,0,0,0,30,Earth,10,1,20,0,0,0,0,0
          Chameleon,            Attack,0,0,1,Physical Damage(STR),110,170,160,One Enemy,1,91,100,0,60,9999,0,0,0,0,60,Fire,0,1,15,0,0,0,0,0

--- a/docs/ENEMY_MOVES_NORMAL.CSV
+++ b/docs/ENEMY_MOVES_NORMAL.CSV
@@ -1,4 +1,4 @@
-Enemy,Move,MP,SP,???,Target Effect,STR,POW,AD,Target Type,???,Distance,Accuracy,Range,Cast Time,Recovery,Animation,Knockdown,IP Stun,IP Cancel Stun,Knockback,Element,Element Strength,Status Effect Bitflag,Status Effect Chance,ATK Change,DEF Change,ACT Change,MOV Change,Special
+Enemy,Move,MP,SP,???,Target Effect,STR,POW,AD,Target Type,Normal Attack Flag,Distance,Accuracy,Range,Cast Time,Recovery,Animation,Knockdown,IP Stun,IP Cancel Stun,Knockback,Element,Element Strength,Status Effect Bitflag,Status Effect Chance,ATK Change,DEF Change,ACT Change,MOV Change,Special
           Big Foot,            Attack,0,0,1,Physical Damage(STR),85,200,85,One Enemy,1,150,100,0,60,9999,0,0,0,0,120,Blizzard,9,0,0,0,0,0,0,0
   Huge Caterpillar,            Attack,0,0,20,Physical Damage(STR),90,150,90,One Enemy,1,50,300,0,30,9999,0,0,0,0,30,Earth,10,1,20,0,0,0,0,0
          Chameleon,            Attack,0,0,1,Physical Damage(STR),110,170,160,One Enemy,1,91,100,0,60,9999,0,0,0,0,60,Fire,0,1,15,0,0,0,0,0

--- a/src/EnemiesClass.cpp
+++ b/src/EnemiesClass.cpp
@@ -376,7 +376,7 @@ void EnemiesClass::draw() {
 
 		ImGui::Combo("Target Type", &this->_enemies[this->_enemyIndex].moves[this->_moveIndex].stats.targetType, targetTypes, 16);
 
-		ImGui::InputUByte("Unknown #2", &this->_enemies[this->_enemyIndex].moves[this->_moveIndex].stats.unknown1);
+		ImGui::InputUByte("Unknown #2", &this->_enemies[this->_enemyIndex].moves[this->_moveIndex].stats.normalAttackFlag);
 		ImGui::InputUShort("Distance", &this->_enemies[this->_enemyIndex].moves[this->_moveIndex].stats.distance);             if (ImGui::IsItemHovered()) ImGui::SetTooltip("How far away to use move?");
 		ImGui::InputUShort("Accuracy", &this->_enemies[this->_enemyIndex].moves[this->_moveIndex].stats.accuracy);
 		ImGui::InputUShort("Range", &this->_enemies[this->_enemyIndex].moves[this->_moveIndex].stats.range);                   if (ImGui::IsItemHovered()) ImGui::SetTooltip("How big is the move area?");
@@ -554,7 +554,7 @@ void EnemiesClass::outputToCSV() {
 				<< std::to_string(val.moves[i].stats.pow) << ','
 				<< std::to_string(val.moves[i].stats.ad) << ','
 				<< targetTypes[val.moves[i].stats.targetType] << ','
-				<< std::to_string(val.moves[i].stats.unknown1) << ','
+				<< std::to_string(val.moves[i].stats.normalAttackFlag) << ','
 				<< std::to_string(val.moves[i].stats.distance) << ','
 				<< std::to_string(val.moves[i].stats.accuracy) << ','
 				<< std::to_string(val.moves[i].stats.range) << ','

--- a/src/include/EnemiesClass.h
+++ b/src/include/EnemiesClass.h
@@ -30,7 +30,7 @@ struct EnemyMoveStatsStruct {
 	uint16_t pow = 0;
 	uint16_t ad = 0;
 	uint8_t targetType = 0;
-	uint8_t unknown1 = 0;
+	uint8_t normalAttackFlag = 0;
 	uint16_t distance = 0;
 	uint16_t accuracy = 0;
 	uint16_t range = 0;


### PR DESCRIPTION
Making a pull request with a proper fork and branch. I hope I didn't mess anything up.
Normal / Special Attack Flag:
00 - Special Attack: stop time during move execution, and display its name
01 - Normal Attack, time continues during move execution, do not display its name