### PR TITLE
Implemented temporary fallback for unsupported languages.

### DIFF
--- a/src/G2DataGUI.UI.Common/Locale/LocaleManager.cs
+++ b/src/G2DataGUI.UI.Common/Locale/LocaleManager.cs
@@ -23,7 +23,7 @@ public class LocaleManager : BaseViewModel
 
     public void Load()
     {
-        string systemLanguageCode = CultureInfo.CurrentCulture.Name.Replace("-", "_");
+        string systemLanguageCode = GetSupportedLanguage();
         LoadLanguage(systemLanguageCode);
         LoadDefaultLanguage();
     }
@@ -36,9 +36,17 @@ public class LocaleManager : BaseViewModel
         }
     }
 
-	private void LoadDefaultLanguage() => _defaultLocaleStringLists = LoadJsonLanguage();
+    private void LoadDefaultLanguage() => _defaultLocaleStringLists = LoadJsonLanguage();
 
-	private Dictionary<LocaleKeys, List<string>> LoadJsonLanguage(string languageCode = DefaultLanguageCode)
+    private string GetSupportedLanguage()
+    {
+        string systemLanguage = CultureInfo.CurrentCulture.Name.Replace("-", "_");
+
+        // Todo: Check if systemLanguage is in supported locales, at the moment it's only en_US.
+        return DefaultLanguageCode;
+    }
+
+    private Dictionary<LocaleKeys, List<string>> LoadJsonLanguage(string languageCode = DefaultLanguageCode)
     {
         Dictionary<LocaleKeys, List<string>> localeStringLists = new();
         string jsonData = EmbeddedResources.ReadAllText($"G2DataGUI.UI.Common/Assets/Locales/{languageCode}.json");


### PR DESCRIPTION
Exception is caused when running on en_GB as .json is not found.
While the code I've supplied isn't an elegant fix, it has a fallback for the default supported language, which is currently only en_US.